### PR TITLE
fix(ci): update pnpm/action-setup to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "16"
-      - uses: pnpm/action-setup@v2.2.1
+      - uses: pnpm/action-setup@v4
         with:
           version: 6.0.2
       - run: pnpm install


### PR DESCRIPTION
Updates pnpm/action-setup from v2.2.1 to v4 to fix:
- Deprecated save-state command warnings
- Node.js URLSearchParams TypeError